### PR TITLE
add viewport scale for mobile. media queries for font

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "figaro"
 
 gem "pry"
 
-gem "thin"
+#gem "thin"
 
 gem "geocoder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,10 +51,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
-    daemons (1.2.2)
     debug_inspector (0.0.2)
     erubis (2.7.0)
-    eventmachine (1.0.5)
     execjs (2.7.0)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -153,10 +151,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.4)
@@ -191,7 +185,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  thin
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -36,6 +36,7 @@ p {
 /* Typeography for application */
 
 h1 {
+	text-align: center;
 	color: #8C001A;
 }
 
@@ -44,7 +45,17 @@ h1 {
 
 
 
-
-
-
 /* Media Queries */
+
+@media (max-width: 600px) {
+	p {
+		font-size: 25px;
+	}
+
+	.location-search-input {
+		font-size: 2em;
+	}
+}
+
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
   <title>IsitFuckingOpen</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
@@ -12,3 +13,4 @@
 
 </body>
 </html>
+  


### PR DESCRIPTION
Using dev tools i tested the loading of a different device.

the viewport scales the site

the header is now text align center.

the font-size for the input changed depending on view port size using media queries.

(thin gem was removed for me to run server... lol)

